### PR TITLE
PgServer fails to start unless user is an Administrator

### DIFF
--- a/src/MysticMind.PostgresEmbed/PgServer.cs
+++ b/src/MysticMind.PostgresEmbed/PgServer.cs
@@ -446,7 +446,10 @@ namespace MysticMind.PostgresEmbed
                 ExtractPgBinary();
                 ExtractPgExtensions();
 
-                AddLocalUserAccessPermission();
+                if (_addLocalUserAccessPermission)
+                {
+                    AddLocalUserAccessPermission();
+                }
 
                 InitDb();
                 StartServer();


### PR DESCRIPTION
- Observe the setting of _addLocalUserAccessPermission in the constructor.
- Change to using DirectorySecurity for querying and setting permissions.
- Do not set access rule if already have access.