### PR TITLE
hide console windows when start server

### DIFF
--- a/src/MysticMind.PostgresEmbed/PgServer.cs
+++ b/src/MysticMind.PostgresEmbed/PgServer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Diagnostics;
 using System.Collections.Generic;
@@ -372,6 +372,7 @@ namespace MysticMind.PostgresEmbed
 
                 _pgServerProcess.StartInfo.FileName = filename;
                 _pgServerProcess.StartInfo.Arguments = string.Join(" ", args);
+                _pgServerProcess.StartInfo.CreateNoWindow = true;
 
                 _pgServerProcess.Start();
 

--- a/src/MysticMind.PostgresEmbed/Utils.cs
+++ b/src/MysticMind.PostgresEmbed/Utils.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -152,6 +152,7 @@ namespace MysticMind.PostgresEmbed
 
                 p.StartInfo.FileName = filename;
                 p.StartInfo.Arguments = string.Join(" ", args);
+                p.StartInfo.CreateNoWindow = true;
 
                 p.Start();
 


### PR DESCRIPTION
Please, accept
Too many console windows on windows 10 during tests running