### PR TITLE
Query nuget for the download uri

### DIFF
--- a/src/MysticMind.PostgresEmbed/MysticMind.PostgresEmbed.csproj
+++ b/src/MysticMind.PostgresEmbed/MysticMind.PostgresEmbed.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="System.Net.NetworkInformation" Version="4.3.0" />
     <PackageReference Include="System.Net.Http" Version="4.3.3" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
+    <PackageReference Include="NuGet.Protocol" Version="4.9.4" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">


### PR DESCRIPTION
Rather than hardcoding the uri to download PostgreSql.Binaries.Lite from
we use the nuget client SDK to load the users settings and query nuget
for the uri. This will allow the downloader to work even when nuget is
set up to use proxies, mirrors, local caches or other scenarios
(anything that nuget.exe install supports this should now support).