### PR TITLE
Do not create the data directory.  initdb will create the directory w…

### DIFF
--- a/src/MysticMind.PostgresEmbed/PgServer.cs
+++ b/src/MysticMind.PostgresEmbed/PgServer.cs
@@ -191,7 +191,6 @@ namespace MysticMind.PostgresEmbed
             Directory.CreateDirectory(DbDir);
             Directory.CreateDirectory(BinariesDir);
             Directory.CreateDirectory(PgDir);
-            Directory.CreateDirectory(DataDir);
         }
 
         private void RemoveWorkingDir() => DeleteDirectory(DbDir);


### PR DESCRIPTION
…ith the right permissions.

This fixes a failure on my build server:

```
  ----> System.Exception : InitDb execution returned an error code 1 The files belonging to this database system will be owned by user "user".
This user must also own the server process.
The database cluster will be initialized with locale "English_United Kingdom.1252".
The default text search configuration will be set to "english".
Data page checksums are disabled.
fixing permissions on existing directory ./pg_embed/543ea5d9-d737-4b41-85ff-8838f6c7c155/data ... 
 initdb: could not change permissions of directory "./pg_embed/543ea5d9-d737-4b41-85ff-8838f6c7c155/data": Permission denied
```