### PR TITLE
support for different nuget package name on PgServer constructor

### DIFF
--- a/src/MysticMind.PostgresEmbed/BinariesLitePgBinaryDownloader.cs
+++ b/src/MysticMind.PostgresEmbed/BinariesLitePgBinaryDownloader.cs
@@ -23,10 +23,13 @@ namespace MysticMind.PostgresEmbed
 
         private readonly string _destDir;
 
-        public PgBinariesLiteBinaryDownloader(string pgVersion, string destDir)
+        private readonly string _nugetPackage;
+
+        public PgBinariesLiteBinaryDownloader(string pgVersion, string destDir, string nugetPackage)
         {
             _pgVersion = pgVersion;
             _destDir = destDir;
+            _nugetPackage = nugetPackage ?? "PostgreSql.Binaries.Lite";
         }
 
         private async Task<Uri> GetNugetUri(CancellationToken cancellationToken)
@@ -34,7 +37,7 @@ namespace MysticMind.PostgresEmbed
             var settings = Settings.LoadDefaultSettings(null);
             var packageSourceProvider = new PackageSourceProvider(settings);
             var sourceRepositoryProvider = new SourceRepositoryProvider(packageSourceProvider, FactoryExtensionsV3.GetCoreV3(Repository.Provider));
-            var package = new PackageIdentity("PostgreSql.Binaries.Lite", NuGetVersion.Parse(_pgVersion));
+            var package = new PackageIdentity(_nugetPackage, NuGetVersion.Parse(_pgVersion));
             
             var pathContext = NuGetPathContext.Create(settings);
             var localSources = new List<string> { pathContext.UserPackageFolder };
@@ -56,7 +59,7 @@ namespace MysticMind.PostgresEmbed
                 }
             }
 
-            throw new Exception("Could not find PostgreSql.Binaries.Lite package");
+            throw new Exception($"Could not find {_nugetPackage} package");
         }
 
         public string Download()
@@ -81,7 +84,7 @@ namespace MysticMind.PostgresEmbed
             else
             {
                 // Download from the nuget repository
-                var downloadPath = Path.Combine(_destDir, $@"PostgreSql.Binaries.Lite.{_pgVersion}.nupkg");
+                var downloadPath = Path.Combine(_destDir, $@"{_nugetPackage}.{_pgVersion}.nupkg");
                 var progress = new Progress<double>();
                 progress.ProgressChanged += (sender, value) => Console.WriteLine("\r %{0:N0}", value);
                 Utils.DownloadAsync(url.AbsoluteUri, downloadPath, progress, cs.Token).Wait();

--- a/src/MysticMind.PostgresEmbed/PgServer.cs
+++ b/src/MysticMind.PostgresEmbed/PgServer.cs
@@ -44,6 +44,7 @@ namespace MysticMind.PostgresEmbed
 
         private readonly Policy _downloadRetryPolicy;
         private readonly Policy _deleteFoldersRetryPolicy;
+        public string _nugetPackage { get; private set; }
 
         public PgServer(
             string pgVersion,
@@ -59,7 +60,8 @@ namespace MysticMind.PostgresEmbed
             int deleteFolderRetryCount =5, 
             int deleteFolderInitialTimeout =16, 
             int deleteFolderTimeoutFactor =2,
-            string locale = null)
+            string locale = null,
+            string nugetPackage = null)
         {
             PgVersion = pgVersion;
 
@@ -94,7 +96,8 @@ namespace MysticMind.PostgresEmbed
             PgDir = Path.Combine(InstanceDir, "pgsql");
             PgBinDir = Path.Combine(PgDir, "bin");
             DataDir = Path.Combine(InstanceDir, "data");
-            
+
+            _nugetPackage = nugetPackage;
 
             // setup the policy for retry pertaining to downloading binary
             _downloadRetryPolicy =
@@ -135,7 +138,7 @@ namespace MysticMind.PostgresEmbed
 
         private void DownloadPgBinary()
         {
-            var downloader = new PgBinariesLiteBinaryDownloader(PgVersion, BinariesDir);
+            var downloader = new PgBinariesLiteBinaryDownloader(PgVersion, BinariesDir, _nugetPackage);
 
             try
             {

--- a/src/MysticMind.PostgresEmbed/PgServer.cs
+++ b/src/MysticMind.PostgresEmbed/PgServer.cs
@@ -44,7 +44,7 @@ namespace MysticMind.PostgresEmbed
 
         private readonly Policy _downloadRetryPolicy;
         private readonly Policy _deleteFoldersRetryPolicy;
-        public string _nugetPackage { get; private set; }
+        private readonly string _nugetPackage;
 
         public PgServer(
             string pgVersion,


### PR DESCRIPTION
package [PostgreSql.Binaries.Lite](https://github.com/mihasic/PostgreSql.Binaries.Lite) is a bit old; [last nuget version](https://www.nuget.org/packages/PostgreSql.Binaries.Lite) is dated back to 4/9/2019, providing PostgreSQL version postgresql-10.7-1.

In order to give the user the possibility to use a different postgresql version or distribution, I've added an optional constructor parameter to the PgServer class that pushes a different nuget package name to the Downloader.

The default behaviour is obviously unchanged.

