### PR TITLE
Support custom maven repositories

### DIFF
--- a/src/MysticMind.PostgresEmbed/DefaultPostgresBinaryDownloader.cs
+++ b/src/MysticMind.PostgresEmbed/DefaultPostgresBinaryDownloader.cs
@@ -13,6 +13,7 @@ internal class DefaultPostgresBinaryDownloader
     private readonly Platform _platform;
     private readonly Architecture? _architecture;
     private readonly string _destDir;
+    private readonly string _mavenRepo;
 
     /// <summary>
     /// The default Postgres binary downloader uses https://github.com/zonkyio/embedded-postgres-binaries
@@ -22,12 +23,14 @@ internal class DefaultPostgresBinaryDownloader
     /// <param name="pgVersion"></param>
     /// <param name="platform"></param>
     /// <param name="architecture"></param>
-    public DefaultPostgresBinaryDownloader(string pgVersion, string destDir, Platform platform, Architecture? architecture)
+    /// <param name="mavenRepo"></param>
+    public DefaultPostgresBinaryDownloader(string pgVersion, string destDir, Platform platform, Architecture? architecture, string mavenRepo)
     {
         _destDir = destDir;
         _pgVersion = pgVersion;
         _platform = platform;
         _architecture = architecture;
+        _mavenRepo = mavenRepo;
     }
 
     public string Download()
@@ -45,7 +48,7 @@ internal class DefaultPostgresBinaryDownloader
             architecture = "alpine-lite";
         }
         
-        var downloadUrl = $"https://repo1.maven.org/maven2/io/zonky/test/postgres/embedded-postgres-binaries-{platform}-{architecture}/{_pgVersion}/embedded-postgres-binaries-{platform}-{architecture}-{_pgVersion}.jar";
+        var downloadUrl = $"{_mavenRepo}/io/zonky/test/postgres/embedded-postgres-binaries-{platform}-{architecture}/{_pgVersion}/embedded-postgres-binaries-{platform}-{architecture}-{_pgVersion}.jar";
         var fileName = Path.GetFileName(downloadUrl);
         var destFile = Path.Join(_destDir, fileName);
         var zipFile = Path.Join(_destDir, Path.GetFileNameWithoutExtension(fileName) + ".txz");

--- a/src/MysticMind.PostgresEmbed/PgServer.cs
+++ b/src/MysticMind.PostgresEmbed/PgServer.cs
@@ -42,6 +42,7 @@ namespace MysticMind.PostgresEmbed
         
         private readonly Platform _platform;
         private readonly Architecture _architecture;
+        private readonly string _mavenRepo;
 
         public PgServer(
             string pgVersion,
@@ -58,7 +59,8 @@ namespace MysticMind.PostgresEmbed
             int deleteFolderInitialTimeout =16, 
             int deleteFolderTimeoutFactor =2,
             string locale = "",
-            Platform? platform = null)
+            Platform? platform = null,
+            string mavenRepo = "https://repo1.maven.org/maven2")
         {
             
             _pgCtlBin = "pg_ctl";
@@ -83,6 +85,8 @@ namespace MysticMind.PostgresEmbed
             _platform = platform.Value;
             
             _architecture = Utils.GetArchitecture(_platform);
+
+            _mavenRepo = mavenRepo;
 
             PgUser = String.IsNullOrEmpty(pgUser) ? PgSuperuser : pgUser;
 
@@ -157,7 +161,7 @@ namespace MysticMind.PostgresEmbed
 
         private void DownloadPgBinary()
         {
-            var downloader = new DefaultPostgresBinaryDownloader(PgVersion, BinariesDir, _platform, _architecture);
+            var downloader = new DefaultPostgresBinaryDownloader(PgVersion, BinariesDir, _platform, _architecture, _mavenRepo);
 
             try
             {


### PR DESCRIPTION
It's fantastic the package now supports Linux, but it also now has a hard dependency on `https://repo1.maven.org/maven2`. This PR would allow for the embedded Postgres binaries to be obtained from another maven repository source.